### PR TITLE
temp: desabiltando build da imagem python no build.yml até corrigir Dockerfile do python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/${{ steps.repo.outputs.repository }}/php-cli:buildcache,mode=max
 
       - name: Build and push API (python) image
+        if: false  # Dockerfile da api está quebrada, depois de arrumar, remover esta linha
         uses: docker/build-push-action@v5
         with:
           # contexto na pasta api (Dockerfile está em api/Dockerfile)


### PR DESCRIPTION
Arrumando temporariamente a pipeline de CD, desabilitando o build da imagem quebrada do python

Closes #44 