### PR TITLE
feat(api-python): removendo exposição publica e configurando a api

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,16 @@
 from fastapi import FastAPI
 from api.V1.endpoints import bancos
+import uvicorn
 
 API_V1_STR: str = '/api/v1'
 
 app = FastAPI(title="Analise de Arquivos")
+
+@app.get("/health")
+async def health_check():
+    return {"status": "healthy", "version": "1.0"}
+
 app.include_router(bancos.router, prefix=API_V1_STR)
 
 if __name__ == '__main__':
-    import uvicorn
-    uvicorn.run("main:app", host="127.0.0.1", port=8000, log_level="info",reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level="info",reload=True)

--- a/docker/production/nginx/nginx.conf
+++ b/docker/production/nginx/nginx.conf
@@ -57,27 +57,6 @@ http {
         # Tamanho máximo de upload (ajuste conforme necessário para seus arquivos)
         client_max_body_size 100M;
 
-        # Proxy reverso para a API Python
-        location /api/python/ {
-            proxy_pass http://python-api/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_cache_bypass $http_upgrade;
-            
-            # Timeouts aumentados para processamento de arquivos
-            proxy_connect_timeout 300s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
-            
-            # Buffering para uploads grandes
-            proxy_request_buffering off;
-        }
-
         # Rota principal que envia tudo para o index.php do Laravel
         location / {
             try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
- Remove exposição pública da API Python do Nginx
- Configura API para aceitar conexões apenas da rede Docker
- Ajusta host do uvicorn de 127.0.0.1 para 0.0.0.0
- Adiciona endpoint /health para healthcheck
