### PR TITLE
feat(imports): criando método de importar arquivo no service de comu…

### DIFF
--- a/app/Services/PythonApiService.php
+++ b/app/Services/PythonApiService.php
@@ -3,7 +3,9 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\Http;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
+use Exception;
 
 class PythonApiService
 {
@@ -34,6 +36,28 @@ class PythonApiService
         } catch (\Exception $e) {
             Log::error('Python API health check falhou', ['error' => $e->getMessage()]);
             return false;
+        }
+    }
+
+    public function processarArquivo(UploadedFile $file, array $options = []): array
+    {
+        try {
+            $response = Http::withHeaders($this->getHeaders())
+            ->timeout($this->timeout)
+            ->attach('file', file_get_contents($file->getRealPath()), $file->getClientOriginalName())
+            ->post("{$this->baseUrl}/processarArqu", $options);
+
+            if ($response->failed()) {
+                throw new Exception("Erro na API Python: " . $response->body());
+            }
+
+            return $response->json();
+        } catch (Exception $e) {
+            Log::error('Erro ao processar arquivo na API Python', [
+                'error' => $e->getMessage(),
+                'file' => $file->getClientOriginalName()
+            ]);
+            throw $e;
         }
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,11 +62,8 @@ Route::middleware([
     Route::get('/lancamentos/import', [ImportController::class, 'index'])
         ->name('lancamentos.import');
 
-    Route::post('/lancamentos/import/spreadsheets', [ImportController::class, 'importSpreadsheets'])
-        ->name('lancamentos.import.spreadsheets');
-
-    Route::post('/lancamentos/import/statements', [ImportController::class, 'importStatements'])
-        ->name('lancamentos.import.statements');
+    Route::post('/lancamentos/import', [ImportController::class, 'importArquivo'])
+        ->name('lancamentos.import.store');
 
     Route::get('/lancamentos/import/template', [ImportController::class, 'downloadTemplate'])
         ->name('lancamentos.import.template');


### PR DESCRIPTION
Esta solicitação de pull request refatora a importação de documentos financeiros integrando PythonApiService:

- Substitui lógica de marcador por processamento real via API Python
- Adiciona método `processarArquivo` no `PythonApiService` com validação, tratamento de erros e logging
- Renomeia e atualiza `import` para `importArquivo` no `ImportController` com processamento de múltiplos arquivos
- Consolida rotas de importação em `routes/web.php`
- Melhora tratamento de exceções com feedback informativo ao usuário